### PR TITLE
fix: initialize record button after element lookup

### DIFF
--- a/app/web/static/app.js
+++ b/app/web/static/app.js
@@ -199,7 +199,6 @@ els.time = document.getElementById("time");
 // initial load
 loadPantry();
 renderStaged();
-updateRecordButton(false);
 
 // ---------------- Voice Ingest ----------------
 let mediaRecorder = null;
@@ -211,6 +210,8 @@ const vEls = {
   transcript: document.getElementById("rec-transcript"),
   merge: document.getElementById("rec-merge"),
 };
+
+updateRecordButton(false);
 
 async function startRecording() {
   try {


### PR DESCRIPTION
## Summary
- ensure the record button is initialized after its DOM elements are defined

## Testing
- `node - <<'NODE'...NODE`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68ac87a50bf8832e9e2b352deba84598