### PR TITLE
Improve UX feedback and pantry persistence

### DIFF
--- a/app/web/static/app.css
+++ b/app/web/static/app.css
@@ -26,8 +26,4 @@ td:last-child { text-align:right; }
 #staged-list { list-style:none; margin:8px 0 0 0; padding:0; }
 #staged-list li { background:var(--card); border:1px solid #ddd; border-radius:8px; padding:6px 8px; margin-top:4px; }
 
-.burger { background:none; border:none; font-size:24px; padding:4px; }
-.drawer { position:fixed; top:0; left:0; width:260px; height:100%; background:#fff; border-right:1px solid #ddd; padding:16px; transform:translateX(-100%); transition:transform .3s; overflow:auto; z-index:1000; }
-.drawer.open { transform:translateX(0); }
-.drawer-overlay { position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.3); display:none; z-index:999; }
-.drawer.open + .drawer-overlay { display:block; }
+.status { color: var(--muted); }

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -8,16 +8,11 @@
 </head>
 <body>
   <header class="nav">
-    <button id="drawer-toggle" class="burger" aria-label="Menu">&#9776;</button>
     <div class="brand">Pantry</div>
     <nav>
-      <a href="/">Home</a>
+      {% block nav %}{% endblock %}
     </nav>
   </header>
-  <aside id="drawer" class="drawer">
-    {% block drawer %}{% endblock %}
-  </aside>
-  <div id="drawer-overlay" class="drawer-overlay"></div>
   <main class="container">
     {% block content %}{% endblock %}
   </main>

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -1,17 +1,19 @@
 {% extends "base.html" %}
 
-{% block drawer %}
-<nav>
-  <a href="#pantry" class="drawer-link">Pantry</a>
-  <a href="#voice" class="drawer-link">Voice Ingest</a>
-  <a href="#recipes-section" class="drawer-link">Recipes</a>
-</nav>
+{% block nav %}
+  <a href="#pantry">Pantry</a>
+  <a href="#voice">Voice Ingest</a>
+  <a href="#recipes-section">Recipes</a>
 {% endblock %}
 
 {% block content %}
 
 <section id="pantry" class="card">
-  <h1><b>Pantry</b></h1>
+  <div class="row">
+    <h1><b>Pantry</b></h1>
+    <button id="pantry-toggle">Hide</button>
+  </div>
+  <div id="pantry-content">
   <div id="pantry-controls">
     <button id="refresh">Refresh</button>
     <button id="save">Replace Pantry</button>
@@ -31,6 +33,7 @@
     <input id="new-qty" type="number" min="0" step="0.01" placeholder="Qty" />
     <input id="new-unit" placeholder="Unit (g, ml, cup, piece)" />
     <button id="add-row">Add</button>
+  </div>
   </div>
 </section>
 
@@ -52,6 +55,9 @@
   </div>
   <div class="row">
     <audio id="rec-audio" controls hidden></audio>
+  </div>
+  <div class="row">
+    <div id="transcribe-status" class="status" hidden></div>
   </div>
   <div class="row">
     <textarea id="rec-transcript" rows="3" placeholder="Transcript will appear here..." style="width:100%;"></textarea>
@@ -77,7 +83,7 @@
     </div>
     <button type="submit">Suggest</button>
   </form>
-
+  <div id="suggest-status" class="status" hidden></div>
   <div id="recipes"></div>
 </section>
 


### PR DESCRIPTION
## Summary
- show progress while voice transcription is running and confirm when complete
- disable Suggest button during recipe generation and display progress
- persist pantry deletions to backend and allow pantry section to be collapsed
- simplify navigation by removing burger menu

## Testing
- `pip install -r requirements.txt` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68ac90dfcfac832e996f6747ec288073